### PR TITLE
msm8974-common: Add prebuilt protobuf from sdk29

### DIFF
--- a/msm8974.mk
+++ b/msm8974.mk
@@ -175,6 +175,10 @@ PRODUCT_PACKAGES += \
     timekeep \
     TimeKeep
 
+# VNDK
+PRODUCT_COPY_FILES += \
+    prebuilts/vndk/v29/arm/arch-arm-armv7-a-neon/shared/vndk-core/libprotobuf-cpp-lite.so:$(TARGET_COPY_OUT_VENDOR)/lib/libprotobuf-cpp-lite-v29.so
+
 # Wifi
 PRODUCT_PACKAGES += \
     libwpa_client \


### PR DESCRIPTION
This is needed for our prebuilt DRM library.

Change-Id: I980a9e66cc0f99b5292210428c6ae9737e5b3969
